### PR TITLE
Optimization of add_frc_steps()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1231,7 +1231,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	 r[m].lvl_id=s[i].lvl_id;
 	 m+=1;
    }*/
-   int n,m,l,i,j;
+   /*int n,m,l,i,j;
    int index_mom_update_s, index_mom_update_r;
    mdstep_t *tmp;
    n=nfrc_steps(s);
@@ -1256,11 +1256,11 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   break;
 	}
 	index_mom_update_r = m-1;
-   }
+   }*/
 
    /* tmp will store the momentum update, as well as any operations belonging to force-gradient updates from r. 
       It will moreover already contain the momentum update from s, if it exists. */
-   if (index_mom_update_r >= 0)
+   /*if (index_mom_update_r >= 0)
    	tmp = (mdstep_t *)malloc((m - index_mom_update_r) * sizeof(mdstep_t));
    else 
 	tmp = (mdstep_t *)malloc(m * sizeof(mdstep_t));
@@ -1291,10 +1291,10 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[i].eps = r[i+index_mom_update_r].eps;
 	tmp[i].lvl_id = r[i+index_mom_update_r].lvl_id;
    }
-   l = m-index_mom_update_r;
+   l = m-index_mom_update_r;*/
 
    /* in a next step, we will add all force updates from s to r that do not belong to any force-gradient update */
-   for (i=0;i<index_mom_update_s;i++)
+   /*for (i=0;i<index_mom_update_s;i++)
    {	   
    	for (j=0;j<index_mom_update_r;j++)
 	{
@@ -1311,25 +1311,50 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 		r[j].lvl_id = s[i].lvl_id;
 		index_mom_update_r+=1;
 	}
-   }
+   }*/
 
    /* next, we will append the operations stored in tmp to r */
-   for (i=0;i<l;i++)
+   /*for (i=0;i<l;i++)
    {
 	r[index_mom_update_r].iop = tmp[i].iop;
 	r[index_mom_update_r].eps = tmp[i].eps;
 	r[index_mom_update_r].lvl_id = tmp[i].lvl_id;
 	index_mom_update_r+=1;
    }
-   free(tmp);	
+   free(tmp);	*/
 
    /* finally, we will append the operations from s that belong to force-gradient updates */
-   for (i=index_mom_update_s+1;i<n;i++)
+   /*for (i=index_mom_update_s+1;i<n;i++)
    {
 	r[index_mom_update_r].iop = s[i].iop;
 	r[index_mom_update_r].eps = c*s[i].eps;
 	r[index_mom_update_r].lvl_id = s[i].lvl_id;
 	index_mom_update_r+=1;
+   }*/
+
+   int n,m,i,j;
+
+   n=nfrc_steps(s);
+   m=nfrc_steps(r);
+
+   for (i=0;i<n;i++)
+   {
+      for (j=0;j<m;j++)
+      {
+         if (r[j].iop==s[i].iop)
+         {
+            r[j].eps+=c*s[i].eps;
+            break;
+         }
+      }
+
+      if (j==m)
+      {
+         r[j].iop=s[i].iop;
+         r[j].eps=c*s[i].eps;
+	 r[j].lvl_id=s[i].lvl_id;
+         m+=1;
+      }
    }
 }
 

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1216,9 +1216,27 @@ static int nall_steps(mdstep_t *s)
    return n;
 }
 
+static void swap_steps(mdstep_t *s,mdstep_t *r)
+{
+   int is;
+   double rs;
+
+   is=(*s).iop;
+   (*s).iop=(*r).iop;
+   (*r).iop=is;
+
+   rs=(*s).eps;
+   (*s).eps=(*r).eps;
+   (*r).eps=rs;
+    
+   is=(*s).lvl_id;
+   (*s).lvl_id=(*r).lvl_id;
+   (*r).lvl_id=lvl_id;
+}
+
 static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 {
-   int n,m,i,j;
+    int n,m,i,j;
 
     n=nfrc_steps(s);
     m=nfrc_steps(r);
@@ -1227,7 +1245,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
     {
        for (j=0;j<m;j++)
        {
-          if (r[j].iop==s[i].iop && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id == -1)
+          if (r[j].iop==s[i].iop && r[j].lvl_id = s[i].lvl_id && r[j].lvl_id == -1)
           {
              r[j].eps+=c*s[i].eps;
              break;
@@ -1241,9 +1259,30 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
           m+=1;
        }
     }
-    r[m].iop=iend-4;
-    r[m].eps=0.0;
-    r[m].lvl_id=-1;
+    
+    /* optimization block starts here */
+    for (j=m-1;j>=0;j--)
+    {
+        if (r[j].iop == iend-4)
+            break;
+        else if (r[j].iop < iend-4 && r[j].lvl_id == -1)
+        {
+            i = 1;
+            while (r[j-i].iop != iend-4)
+            {
+                swap_steps(r+j-i+1,r+j-i);
+                i+=1;
+            }
+            swap_steps(r+j-i+1,r+j-i);
+        }
+    }
+    
+    /*if (r[m-1].iop < iend-4)
+    {
+        r[m].iop=itu-3;
+        r[m].eps=0.0;
+        r[m].lvl_id=-1;
+    }*/
 }
 
 

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1291,7 +1291,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[i].eps = r[i+index_mom_update_r].eps;
 	tmp[i].lvl_id = r[i+index_mom_update_r].lvl_id;
    }
-   l = m-index_mom_update;
+   l = m-index_mom_update_r;
 
    /* in a next step, we will add all force updates from s to r that do not belong to any force-gradient update */
    for (i=0;i<index_mom_update_s;i++)

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1236,6 +1236,8 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
    mdstep_t *tmp;
    n=nfrc_steps(s);
    m=nfrc_steps(r);
+   index_mom_update_s = 0;
+   index_mom_update_r = 0;
 
    for(i=0;i<n;i++)
    {	   
@@ -1255,8 +1257,11 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
    }
 
    /* tmp will store the momentum update, as well as any operations belonging to force-gradient updates from r. 
-      It will moreover already contain the momentum update from s, if it exists. */	
-   tmp = (mdstep_t *)malloc((m - index_mom_update_r) * sizeof(mdstep_t));
+      It will moreover already contain the momentum update from s, if it exists. */
+   if (index_mom_update_r >= 0)
+   	tmp = (mdstep_t *)malloc((m - index_mom_update_r) * sizeof(mdstep_t));
+   else 
+	tmp = (mdstep_t *)malloc(m * sizeof(mdstep_t));
 
    if (index_mom_update_r >= 0)
    {
@@ -1274,6 +1279,9 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[0].eps = c*s[index_mom_update_s].eps;
 	tmp[0].lvl_id = s[index_mom_update_s].lvl_id;   
    }   
+
+   if (index_mom_update_r == -1)
+	index_mom_update_r = 0;
 
    for (i=1;i<m-index_mom_update_r;i++)
    {

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1253,9 +1253,9 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
              r[j].eps+=c*s[i].eps;
              break;
           }
-          else if (r[j].iop == s[i].iop && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id >= 0 && r[j].eps == s[i].eps)
+          else if (r[j].iop < iend-4 && s[i].iop < iend-4 && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id >= 0 && r[j].eps == c*s[i].eps)
           {
-              /* there are two force-gradient updates that we can merge sind the temporary updates of the link field use the same step size */
+              /* there are two force-gradient updates that we can merge since the temporary updates of the link field use the same step size */
               /* first, we skip all force updates for the temporary link update */
               while (s[i].iop != iend-3)
               {
@@ -1273,8 +1273,9 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
                   r[j].eps+=c*s[i].eps;
                   i+=1; j+=1;
               }
-              /* finally, we skip the momentum update that also restores the link field */
-              i+=1; j+=1;
+              /* we are now done with merging the two force-gradient updates. The current operation s[i] is performing the momentum update 
+	       * + restoring the link field. This is already in r so that we can skip this operation. */
+              break;
           }
        }
 

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1216,97 +1216,34 @@ static int nall_steps(mdstep_t *s)
    return n;
 }
 
-static void swap_steps(mdstep_t *s,mdstep_t *r)
-{
-   int is;
-   double rs;
-
-   is=(*s).iop;
-   (*s).iop=(*r).iop;
-   (*r).iop=is;
-
-   rs=(*s).eps;
-   (*s).eps=(*r).eps;
-   (*r).eps=rs;
-    
-   is=(*s).lvl_id;
-   (*s).lvl_id=(*r).lvl_id;
-   (*r).lvl_id=is;
-}
-
 static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 {
    int n,m,i,j;
-   mdstep_t *tmp;
 
-   n=nfrc_steps(s);
-   m=nfrc_steps(r);
-    
-   tmp = (mdstep_t *)malloc((m+n) * sizeof(mdstep_t));
-    
-   for (j=0;j<m;j++)
-   {
-       tmp[j].iop = r[j].iop;
-       tmp[j].eps = r[j].eps;
-       tmp[j].lvl_id = r[j].lvl_id;
-   }
-    
-   for (i=0;i<n;i++)
-   {
+    n=nfrc_steps(s);
+    m=nfrc_steps(r);
+
+    for (i=0;i<n;i++)
+    {
        for (j=0;j<m;j++)
        {
-           if (tmp[j].iop==s[i].iop && tmp[j].lvl_id == s[i].lvl_id && tmp[j].lvl_id == -1)
-           {
-               tmp[j].eps+=c*s[i].eps;
-               break;
-           }
+          if (r[j].iop==s[i].iop && r[j].lvl_id = s[i].lvl_id && r[j].lvl_id == -1)
+          {
+             r[j].eps+=c*s[i].eps;
+             break;
+          }
        }
-       
+
        if (j==m)
        {
-           tmp[j].iop=s[i].iop;
-           tmp[j].eps=c*s[i].eps;
-           tmp[j].lvl_id=s[i].lvl_id;
-           m+=1;
+          r[j].iop=s[i].iop;
+          r[j].eps=c*s[i].eps;
+          m+=1;
        }
-   }
-    
-    for (i=1;i<=m;i++)
-    {
-        if (tmp[m-i].iop < iend-4 && tmp[m-i].lvl_id == -1)
-        {
-            j = 1;
-            while(m-(i+j) >= 0)
-            {
-                swap_steps(tmp+m-(i+j)+1,tmp+m-(i+j));
-                j+=1;
-            }
-        }
     }
-    
-    j=0;
-    while (tmp[j].iop != iend-4)
-    {
-        r[j].iop = tmp[j].iop;
-        r[j].eps = tmp[j].eps;
-        r[j].lvl_id = tmp[j].lvl_id;
-        j+=1;
-    }
-    r[j].iop = tmp[j].iop;
-    r[j].eps = tmp[j].eps;
-    r[j].lvl_id = tmp[j].lvl_id;
-    j+=1;
-    for (i=j+1;i<m;i++)
-    {
-        if (tmp[i].iop != iend-4)
-        {
-            r[j].iop = tmp[i].iop;
-            r[j].eps = tmp[i].eps;
-            r[j].lvl_id = tmp[i].lvl_id;
-            j+=1;
-        }
-    }
-    free(tmp);
+    r[m].iop=iend-4;
+    r[m].eps=0.0;
+    r[m].lvl_id=-1;
 }
 
 

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1231,7 +1231,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	 r[m].lvl_id=s[i].lvl_id;
 	 m+=1;
    }*/
-   /*int n,m,l,i,j;
+   int n,m,l,i,j;
    int index_mom_update_s, index_mom_update_r;
    mdstep_t *tmp;
    n=nfrc_steps(s);
@@ -1256,11 +1256,11 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   break;
 	}
 	index_mom_update_r = m-1;
-   }*/
+   }
 
    /* tmp will store the momentum update, as well as any operations belonging to force-gradient updates from r. 
       It will moreover already contain the momentum update from s, if it exists. */
-   /*if (index_mom_update_r >= 0)
+   if (index_mom_update_r >= 0)
    	tmp = (mdstep_t *)malloc((m - index_mom_update_r) * sizeof(mdstep_t));
    else 
 	tmp = (mdstep_t *)malloc(m * sizeof(mdstep_t));
@@ -1291,10 +1291,10 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[i].eps = r[i+index_mom_update_r].eps;
 	tmp[i].lvl_id = r[i+index_mom_update_r].lvl_id;
    }
-   l = m-index_mom_update_r;*/
+   l = m-index_mom_update_r;
 
    /* in a next step, we will add all force updates from s to r that do not belong to any force-gradient update */
-   /*for (i=0;i<index_mom_update_s;i++)
+   for (i=0;i<index_mom_update_s;i++)
    {	   
    	for (j=0;j<index_mom_update_r;j++)
 	{
@@ -1311,28 +1311,28 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 		r[j].lvl_id = s[i].lvl_id;
 		index_mom_update_r+=1;
 	}
-   }*/
+   }
 
    /* next, we will append the operations stored in tmp to r */
-   /*for (i=0;i<l;i++)
+   for (i=0;i<l;i++)
    {
 	r[index_mom_update_r].iop = tmp[i].iop;
 	r[index_mom_update_r].eps = tmp[i].eps;
 	r[index_mom_update_r].lvl_id = tmp[i].lvl_id;
 	index_mom_update_r+=1;
    }
-   free(tmp);	*/
+   free(tmp);	
 
    /* finally, we will append the operations from s that belong to force-gradient updates */
-   /*for (i=index_mom_update_s+1;i<n;i++)
+   for (i=index_mom_update_s+1;i<n;i++)
    {
 	r[index_mom_update_r].iop = s[i].iop;
 	r[index_mom_update_r].eps = c*s[i].eps;
 	r[index_mom_update_r].lvl_id = s[i].lvl_id;
 	index_mom_update_r+=1;
-   }*/
+   }
 
-   int n,m,i,j;
+   /*int n,m,i,j;
 
    n=nfrc_steps(s);
    m=nfrc_steps(r);
@@ -1355,7 +1355,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	 r[j].lvl_id=s[i].lvl_id;
          m+=1;
       }
-   }
+   }*/
 }
 
 

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1216,6 +1216,23 @@ static int nall_steps(mdstep_t *s)
    return n;
 }
 
+static void swap_steps(mdstep_t *s,mdstep_t *r)
+{
+   int is;
+   double rs;
+
+   is=(*s).iop;
+   (*s).iop=(*r).iop;
+   (*r).iop=is;
+
+   rs=(*s).eps;
+   (*s).eps=(*r).eps;
+   (*r).eps=rs;
+    
+   is=(*s).lvl_id;
+   (*s).lvl_id=(*r).lvl_id;
+   (*r).lvl_id=is;
+}
 
 static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 {
@@ -1319,24 +1336,6 @@ static void insert_level(mdstep_t *s1,mdstep_t *s2,mdstep_t *r)
       add_frc_steps(1.0,s2,r);
       s2+=nfrc_steps(s2);
    }
-}
-
-static void swap_steps(mdstep_t *s,mdstep_t *r)
-{
-   int is;
-   double rs;
-
-   is=(*s).iop;
-   (*s).iop=(*r).iop;
-   (*r).iop=is;
-
-   rs=(*s).eps;
-   (*s).eps=(*r).eps;
-   (*r).eps=rs;
-    
-   is=(*s).lvl_id;
-   (*s).lvl_id=(*r).lvl_id;
-   (*r).lvl_id=is;
 }
 
 static void set_nlv(int *nlv,double *tau)

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1231,7 +1231,7 @@ static void swap_steps(mdstep_t *s,mdstep_t *r)
     
    is=(*s).lvl_id;
    (*s).lvl_id=(*r).lvl_id;
-   (*r).lvl_id=lvl_id;
+   (*r).lvl_id=is;
 }
 
 static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
@@ -1245,7 +1245,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
     {
        for (j=0;j<m;j++)
        {
-          if (r[j].iop==s[i].iop && r[j].lvl_id = s[i].lvl_id && r[j].lvl_id == -1)
+          if (r[j].iop==s[i].iop && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id == -1)
           {
              r[j].eps+=c*s[i].eps;
              break;

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1253,6 +1253,22 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
              r[j].eps+=c*s[i].eps;
              break;
           }
+	  else if (r[j].iop < iend-4 && r[j].lvl_id == -1)
+	  {
+		/* we found a force update that has to appear in front of the momentum update. Thus we swap the 
+      		present operation with its predecessor until it has been swapped with the momentum update */
+          	i = 1;
+	        while (j-i >= 0)
+	        {
+	            swap_steps(r+j-i+1,r+j-i);
+	            if (r[j-i+1].iop == iend-4)
+	            {
+	                j+=1;
+	                break;
+	            }
+	            i+=1;
+	        }
+	  }		
        }
 
        if (j==m)

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1247,6 +1247,8 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   break;
 	}
    }
+   if (i==n)
+   	index_mom_update_s = n-1;
    for(i=0;i<m;i++)
    {	   
    	if(r[i].lvl_id != -1)
@@ -1255,6 +1257,8 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   break;
 	}
    }
+   if (i==m)
+	index_mom_update_r = m-1;
 
    /* tmp will store the momentum update, as well as any operations belonging to force-gradient updates from r. 
       It will moreover already contain the momentum update from s, if it exists. */

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1253,22 +1253,29 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
              r[j].eps+=c*s[i].eps;
              break;
           }
-	  else if (r[j].iop < iend-4 && r[j].lvl_id == -1)
-	  {
-		/* we found a force update that has to appear in front of the momentum update. Thus we swap the 
-      		present operation with its predecessor until it has been swapped with the momentum update */
-          	i = 1;
-	        while (j-i >= 0)
-	        {
-	            swap_steps(r+j-i+1,r+j-i);
-	            if (r[j-i+1].iop == iend-4)
-	            {
-	                j+=1;
-	                break;
-	            }
-	            i+=1;
-	        }
-	  }		
+          else if (r[j].iop == s[i].iop && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id >= 0 && r[j].eps == s[i].eps)
+          {
+              /* there are two force-gradient updates that we can merge sind the temporary updates of the link field use the same step size */
+              /* first, we skip all force updates for the temporary link update */
+              while (s[i].iop != iend-3)
+              {
+                  i+=1;
+              }
+              while (r[j].iop != iend-3)
+              {
+                  j+=1;
+              }
+              /* second, we also skip the operation creating a copy of the link field */
+              i+=1; j+=1;
+              /* now, we can sum up the step sizes of the forces*/
+              while (s[i].iop != iend-2)
+              {
+                  r[j].eps+=c*s[i].eps;
+                  i+=1; j+=1;
+              }
+              /* finally, we skip the momentum update that also restores the link field */
+              i+=1; j+=1;
+          }
        }
 
        if (j==m)

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1261,12 +1261,12 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
     }
     
     /* optimization block starts here */
-    for (j=m-1;j>=0;j--)
+    for (j=m-1;j>0;j--)
     {
 	if (r[j].iop == iend-4)	 
 	{
 		i=1;
-		while(j-i > 0)
+		while(j-i >= 0)
 		{
 			swap_steps(r+j-i+1,r+j-i);
 			i+=1;
@@ -1274,7 +1274,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 		break;
 	}
     }
-    for (j=m-1;j>=0;j--)
+    for (j=m-1;j>0;j--)
     {
         if (r[j].iop == iend-4)
             break;

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1263,17 +1263,33 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
     /* optimization block starts here */
     for (j=m-1;j>=0;j--)
     {
+	if (r[j].iop == iend-4)	 
+	{
+		i=1;
+		while(j-i > 0)
+		{
+			swap_steps(r+j-i+1,r+j-i);
+			i+=1;
+		}
+		break;
+	}
+    }
+    for (j=m-1;j>=0;j--)
+    {
         if (r[j].iop == iend-4)
             break;
         else if (r[j].iop < iend-4 && r[j].lvl_id == -1)
         {
             i = 1;
-            while (r[j-i].iop != iend-4)
+            while (r[j-i].iop != iend-4 && (j-i) >= 0)
             {
                 swap_steps(r+j-i+1,r+j-i);
                 i+=1;
             }
-            swap_steps(r+j-i+1,r+j-i);
+	    if (j-i >= 0)
+	    {
+            	swap_steps(r+j-i+1,r+j-i);
+	    }
         }
     }
     

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1231,7 +1231,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	 r[m].lvl_id=s[i].lvl_id;
 	 m+=1;
    }*/
-   int n,m,i,j;
+   int n,m,l,i,j;
    int index_mom_update_s, index_mom_update_r;
    mdstep_t *tmp;
    n=nfrc_steps(s);
@@ -1246,9 +1246,8 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   index_mom_update_s = i-1;
 	   break;
 	}
-   }
-   if (i==n)
    	index_mom_update_s = n-1;
+   }
    for(i=0;i<m;i++)
    {	   
    	if(r[i].lvl_id != -1)
@@ -1256,9 +1255,8 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   index_mom_update_r = i-1;
 	   break;
 	}
-   }
-   if (i==m)
 	index_mom_update_r = m-1;
+   }
 
    /* tmp will store the momentum update, as well as any operations belonging to force-gradient updates from r. 
       It will moreover already contain the momentum update from s, if it exists. */
@@ -1293,6 +1291,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[i].eps = r[i+index_mom_update_r].eps;
 	tmp[i].lvl_id = r[i+index_mom_update_r].lvl_id;
    }
+   l = m-index_mom_update;
 
    /* in a next step, we will add all force updates from s to r that do not belong to any force-gradient update */
    for (i=0;i<index_mom_update_s;i++)
@@ -1315,7 +1314,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
    }
 
    /* next, we will append the operations stored in tmp to r */
-   for (i=0;i<m-index_mom_update_r;i++)
+   for (i=0;i<l;i++)
    {
 	r[index_mom_update_r].iop = tmp[i].iop;
 	r[index_mom_update_r].eps = tmp[i].eps;

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1237,7 +1237,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
    n=nfrc_steps(s);
    m=nfrc_steps(r);
 
-   for(i=0,i<n,i++)
+   for(i=0;i<n;i++)
    {	   
    	if(s[i].lvl_id != -1)
    	{	   
@@ -1245,7 +1245,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	   break;
 	}
    }
-   for(i=0,i<m,i++)
+   for(i=0;i<m;i++)
    {	   
    	if(r[i].lvl_id != -1)
    	{	   
@@ -1263,7 +1263,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
 	tmp[0].iop = r[index_mom_update_r].iop;
 	tmp[0].eps = r[index_mom_update_r].eps;
 	tmp[0].lvl_id = r[index_mom_update_r].lvl_id;
-	if (index_mom_update s>=0)
+	if (index_mom_update_s>=0)
 	{
    		tmp[0].eps += c*s[index_mom_update_s].eps;
 	}	

--- a/modules/update/mdsteps.c
+++ b/modules/update/mdsteps.c
@@ -1227,7 +1227,7 @@ static void add_frc_steps(double c,mdstep_t *s,mdstep_t *r)
     {
        for (j=0;j<m;j++)
        {
-          if (r[j].iop==s[i].iop && r[j].lvl_id = s[i].lvl_id && r[j].lvl_id == -1)
+          if (r[j].iop==s[i].iop && r[j].lvl_id == s[i].lvl_id && r[j].lvl_id == -1)
           {
              r[j].eps+=c*s[i].eps;
              break;


### PR DESCRIPTION
the function add_frc_steps in mdsteps.c did not combine force updates, i.e. the integrator did unnecessary force evaluations. The new function combines force updates whenever it is possible. 

_Note: In Hessian-free force-gradient integrators, merging force updates becomes more difficult. If force evaluations are part of a force-gradient update, they can only be merged if the temporary link updates share the same step size. Force updates that are not part of a force-gradient update can be merged as before._